### PR TITLE
Make Get method asynchronous in CategoryController

### DIFF
--- a/web-api-catalog/web-api-catalog/Controllers/CategoryController.cs
+++ b/web-api-catalog/web-api-catalog/Controllers/CategoryController.cs
@@ -16,9 +16,9 @@ public class CategoryController : ControllerBase
 
     [HttpGet]
     [Route("api/[controller]/listcategories")]
-    public ActionResult<IEnumerable<Category>> Get()
+    public async Task<ActionResult<IEnumerable<Category>>> GetAsync()
     {
-        var categories = _context.categories.AsNoTracking().ToList();
+        var categories = await _context.categories.AsNoTracking().ToListAsync();
         
         if(categories is null)
         {


### PR DESCRIPTION
Updated the Get method to return a Task<ActionResult<IEnumerable<Category>>> instead of ActionResult<IEnumerable<Category>>. The method now uses await with ToListAsync() for non-blocking database access, improving API performance.